### PR TITLE
Handle full SQLite db for sqlite::Ntuple

### DIFF
--- a/messagefacility/plugins/sqlite_mfPlugin.cc
+++ b/messagefacility/plugins/sqlite_mfPlugin.cc
@@ -49,7 +49,7 @@ namespace {
     void routePayload(ostringstream const&, mf::ErrorObj const&) override;
 
   private:
-    Connection* connection_;
+    std::unique_ptr<Connection> connection_;
     Ntuple<string,
            string,
            string,
@@ -66,8 +66,6 @@ namespace {
   {
     delete msgTable_;
     msgTable_ = nullptr;
-    delete connection_;
-    connection_ = nullptr;
   }
 
   sqlite3Plugin::sqlite3Plugin(Parameters const& ps)


### PR DESCRIPTION
Make it so that filling the database is not an error. Inserts and flushes of Ntuple become no-ops when a db becomes full.